### PR TITLE
Test RunnerHub with fixed labels

### DIFF
--- a/test-runnerhub.md
+++ b/test-runnerhub.md
@@ -1,0 +1,10 @@
+# Test RunnerHub with Fixed Labels
+
+Testing that workflows now properly use RunnerHub runners after fixing the label mismatch.
+
+## Fixed Issues
+- Changed workflow labels from `git-runner` to `runnerhub`
+- All runners now have matching labels
+- Workflows should now be picked up by the runners
+
+Test time: 2025-06-17 19:17 UTC


### PR DESCRIPTION
Verifying that workflows now properly use RunnerHub runners after fixing the label mismatch from git-runner to runnerhub